### PR TITLE
Fix build with OCaml >= 5.4

### DIFF
--- a/src/cli/command/sse/screen.enabled.ml
+++ b/src/cli/command/sse/screen.enabled.ml
@@ -398,6 +398,7 @@ module Make (E : Metrics.EXPLORATION) (Q : Metrics.QUERY) = struct
               if lockable then (
                 locked := false;
                 Mutex.unlock mutex));
+          out_width = restore_fof.out_width;
         }
     in
     let background_buffer = Buffer.create 4096 in
@@ -422,6 +423,7 @@ module Make (E : Metrics.EXPLORATION) (Q : Metrics.QUERY) = struct
           out_indent =
             Buffer.out_spaces mutex restore_fof.out_string restore_fof.out_flush
               background_buffer;
+          out_width = restore_fof.out_width;
         }
     in
     (restore_fof, logging_fof, drawing_fof, flush_buffer)


### PR DESCRIPTION
Ocaml >=5.4 requires an `output_width` function for formatter output.

**API documentation**
https://ocaml.org/manual/5.4/api/Format.html#meaning

If I am not mistaken, `output_width` is a read-only function and thus does not require locking, hence it is enough to pass `output_width` through to the original formatter. Please note that I have limited experience with the architecture and may have missed specific details about the locking, so it might be a good idea verify this.

**Breaking changes in the OCaml change log**
- https://ocaml.org/releases/5.4.0 (grep for 13570 and/or 13794)
- https://github.com/ocaml/ocaml/pull/13570
- https://github.com/ocaml/ocaml/pull/13794


